### PR TITLE
Use indexed JSON instead of sample JSON in tests

### DIFF
--- a/.github/workflows/generate-and-deploy.yml
+++ b/.github/workflows/generate-and-deploy.yml
@@ -21,7 +21,7 @@ jobs:
           path: |
             ${{ env.FOODDATA_DIR }}
             indexed_FoodData_Central_survey_food_json_2021-10-28.jsons.tar.xz
-          key: ${{ env.FOODDATA_ZIP_URL }}
+          key: v1-${{ env.FOODDATA_ZIP_URL }}
       - name: Download USDA FDC FoodData
         if: steps.download.outputs.cache-hit != 'true'
         run: >

--- a/.github/workflows/generate-and-deploy.yml
+++ b/.github/workflows/generate-and-deploy.yml
@@ -18,7 +18,9 @@ jobs:
         id: download
         uses: actions/cache@v3
         with:
-          path: ${{ env.FOODDATA_DIR }}
+          path: |
+            ${{ env.FOODDATA_DIR }}
+            indexed_FoodData_Central_survey_food_json_2021-10-28.jsons.tar.xz
           key: ${{ env.FOODDATA_ZIP_URL }}
       - name: Download USDA FDC FoodData
         if: steps.download.outputs.cache-hit != 'true'


### PR DESCRIPTION
Small disk footprint is ensured by compressing the indexed JSON.