### PR TITLE
Refactor reference sample CSV I/O into class

### DIFF
--- a/fooddata_vegattributes/annotate_reference_samples.py
+++ b/fooddata_vegattributes/annotate_reference_samples.py
@@ -1,22 +1,17 @@
 import csv
 
-from .reference_samples import load_reference_samples
+from .reference_samples import load_reference_samples, ReferenceSamplesCsv
 
 
 def main():
   reference_samples = load_reference_samples()
-  with open("reference_samples.csv", "w") as f:
-    writer = csv.DictWriter(
-      f,
-      ["fdc_id", "expected_category", "known_failure", "description"],
-      lineterminator="\n",
-    )
-    writer.writeheader()
+  with ReferenceSamplesCsv.from_path("reference_samples.csv", "w") \
+  as reference_samples_csv:
     for reference_sample in reference_samples:
-      writer.writerow({
+      reference_samples_csv.write_reference_sample_dict({
         "fdc_id": reference_sample.food.fdc_id,
         "expected_category": reference_sample.expected_category.name,
-        "known_failure": "Y" if reference_sample.known_failure else "N",
+        "known_failure": reference_sample.known_failure,
         "description": reference_sample.food.description,
       })
 

--- a/fooddata_vegattributes/reference_samples.py
+++ b/fooddata_vegattributes/reference_samples.py
@@ -1,6 +1,8 @@
+from contextlib import ExitStack
 import csv
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from os import PathLike
+from typing import Dict, Generator, List, Optional, TypedDict, Union
 
 from .food import Category, Food
 from .indexed_fooddata import ensure_compressed_indexed_fooddata_json
@@ -12,11 +14,82 @@ class ReferenceSample:
   known_failure: bool = False
   description: Optional[str] = None
 
+class ReferenceSampleDict(TypedDict):
+  fdc_id: int
+  expected_category: str
+  known_failure: bool
+  description: Optional[str]
+
+class ReferenceSamplesCsv:
+  """
+  CSV file containing reference samples.
+  """
+  def __init__(self, file, csv_io: Union[csv.DictWriter, csv.DictReader]):
+    self.file = file
+    self.close_stack = ExitStack()
+    self.csv_io = csv_io
+
+  @classmethod
+  def from_path(
+    cls, path: Union[PathLike, str, bytes], mode="r",
+  ) -> "ReferenceSamplesCsv":
+    """
+    Opens CSV file for reading or writing depending on the given mode.
+    """
+    file = open(path, mode)
+    csv_io: Union[csv.DictWriter, csv.DictReader]
+    if mode == "w" or mode == "a":
+      csv_io = csv.DictWriter(
+        file,
+        ["fdc_id", "expected_category", "known_failure", "description"],
+        lineterminator="\n",
+      )
+      if mode != "a":
+        csv_io.writeheader()
+    elif mode == "r":
+      csv_io = csv.DictReader(file)
+    else:
+      raise ValueError("mode must be one of 'r', or 'w' or 'a'")
+    obj = cls(file=file, csv_io=csv_io)
+    obj.close_stack.enter_context(file)
+    return obj
+
+  def close(self):
+    self.close_stack.close()
+
+  def __enter__(self):
+    return self
+
+  def __exit__(self, *args, **kwargs):
+    self.close()
+
+  def write_reference_sample_dict(self, d: ReferenceSampleDict):
+    assert isinstance(self.csv_io, csv.DictWriter)
+    self.csv_io.writerow({
+      "fdc_id": d["fdc_id"],
+      "expected_category": d["expected_category"],
+      "known_failure": "Y" if d["known_failure"] else "N",
+      "description": d.get("description"),
+    })
+
+  def get_reference_sample_dicts(self) \
+  -> Generator[ReferenceSampleDict, None, None]:
+    assert isinstance(self.csv_io, csv.DictReader)
+    for row in self.csv_io:
+      yield {
+        "fdc_id": int(row["fdc_id"]),
+        "expected_category": row["expected_category"],
+        "known_failure": row["known_failure"] == "Y",
+        "description": row.get("description"),
+      }
+
+
 def load_reference_samples() -> List[ReferenceSample]:
-  with open("reference_samples.csv") as f:
-    reader = csv.DictReader(f)
+  with ReferenceSamplesCsv.from_path("reference_samples.csv", "r") \
+  as reference_samples_csv:
     fdc_ids_to_sample_ds = {
-      int(row["fdc_id"]): row for row in reader
+      sample_d["fdc_id"]: sample_d
+      for sample_d in reference_samples_csv.get_reference_sample_dicts()
     }
   fdc_ids = fdc_ids_to_sample_ds.keys()
   fdc_ids_to_foods = (
@@ -28,9 +101,7 @@ def load_reference_samples() -> List[ReferenceSample]:
       expected_category=(
         Category[fdc_ids_to_sample_ds[fdc_id]["expected_category"]]
       ),
-      known_failure=(
-        fdc_ids_to_sample_ds[fdc_id].get("known_failure", "N") == "Y"
-      ),
+      known_failure=fdc_ids_to_sample_ds[fdc_id]["known_failure"],
     )
     for fdc_id, food in fdc_ids_to_foods.items()
   ]


### PR DESCRIPTION
Similar to how it was done for compressed indexed FoodData JSON.

Obviously no real point to this yet, next step will be to create a full-fledged repository that allows loading the full `ReferenceSample` object with an instantiated `Food` (via a food repository or sth.).