### PR TITLE
Implement tokens that nullify "omni-er" guess

### DIFF
--- a/fooddata_vegattributes/food.py
+++ b/fooddata_vegattributes/food.py
@@ -47,7 +47,10 @@ categories_to_tokens: Dict[TokenCategory, Set[str]] = {
 
   TokenCategory.NULLIFIES_OMNI: {
     'meatless',
-    'vegetarian'
+    'plant based',
+    'plant-based',
+    'vegan',
+    'vegetarian',
   },
 
   TokenCategory.SUGGESTS_VEGAN: {
@@ -89,7 +92,7 @@ categories_to_tokens: Dict[TokenCategory, Set[str]] = {
     'soda', 'soft drink', 'sports drink', 'sprout', 'squash', 'sugar', 'syrup',
     'tabbouleh', 'tahini', 'tamarind', 'tangerine', 'tannier', 'tea', 'tequila',
     'tempeh', 'tofu', 'tomato', 'tortilla', 'truffle', 'turnip',
-    'vegetable', 'vinegar', 'vodka',
+    'vegan', 'vegetable', 'vinegar', 'vodka',
     'wasabi', 'water', 'weed', 'wheat', 'whiskey',
     'yam', 'yeast',
     'zucchini', 'zwieback',
@@ -121,6 +124,7 @@ categories_to_tokens: Dict[TokenCategory, Set[str]] = {
     'paneer', 'pastry', 'pie', 'pizza', 'praline', 'pudding',
     'ranch',
     'tiramisu', 'toffee', 'trifle', 'tzatziki',
+    'vegetarian',
     'waffle', 'whey', 'whipped', 'white russian',
     'yogurt',
   },
@@ -187,6 +191,28 @@ def categorize(description) -> Category:
     category for category, tokens in categories_to_tokens.items()
     if any(name in tokens for name in names_in_desc)
   }
+
+  if TokenCategory.NULLIFIES_OMNI in found_token_categories:
+    omni_nullification_mapping = {
+      TokenCategory.SUGGESTS_OMNI: TokenCategory.SUGGESTS_VEGAN_OR_VEGETARIAN,
+      TokenCategory.SUGGESTS_VEGAN_OR_OMNI: TokenCategory.SUGGESTS_VEGAN,
+      TokenCategory.SUGGESTS_VEGAN_VEGETARIAN_OR_OMNI: (
+        TokenCategory.SUGGESTS_VEGAN_OR_VEGETARIAN
+      ),
+      TokenCategory.SUGGESTS_VEGETARIAN_OR_OMNI: (
+        TokenCategory.SUGGESTS_VEGETARIAN
+      ),
+    }
+    found_token_categories = {
+        token_category for token_category in {
+        (
+          token_category
+          if token_category not in omni_nullification_mapping
+          else omni_nullification_mapping[token_category]
+        ) for token_category in found_token_categories
+      }
+      if token_category is not None
+    }
 
   if TokenCategory.SUGGESTS_OMNI in found_token_categories:
     return Category.OMNI

--- a/reference_samples.csv
+++ b/reference_samples.csv
@@ -36,7 +36,7 @@ fdc_id,expected_category,known_failure,description
 1098434,OMNI,N,"Chicken, NS as to part, grilled with sauce, skin eaten"
 1100393,OMNI,N,Pinto beans with meat
 1100139,OMNI,N,"Chicken or turkey soup, cream of, canned, reduced sodium, made with milk"
-1100019,OMNI,N,"Frankfurter or hot dog sandwich, with meatless chili, on multigrain bun"
+1100019,OMNI,Y,"Frankfurter or hot dog sandwich, with meatless chili, on multigrain bun"
 1101194,VEGAN_OR_VEGETARIAN,Y,"Pastry, puff"
 1099800,OMNI,N,"Hamburger, on wheat bun, 1 small patty"
 1104575,VEGAN,N,"Broccoli, cooked, as ingredient"
@@ -66,7 +66,6 @@ fdc_id,expected_category,known_failure,description
 1099477,OMNI,N,"Pork, potatoes, and vegetables including carrots, broccoli, and/or dark-green leafy; no sauce"
 1098331,OMNI,N,"Pork ears, tail, head, snout, miscellaneous parts, cooked"
 1098091,VEGETARIAN,Y,Welsh rarebit
-1099497,OMNI,N,"Lamb or mutton stew with potatoes and vegetables including carrots, broccoli, and/or dark-green leafy; gravy"
 1102101,VEGETARIAN,N,"Cheese quiche, meatless"
 1099865,OMNI,N,"Chicken fillet sandwich, from school cafeteria"
 1103324,OMNI,N,"Tomato beef rice soup, prepared with water"
@@ -87,4 +86,4 @@ fdc_id,expected_category,known_failure,description
 1104177,VEGETARIAN,N,"Coffee, Cafe Mocha, decaffeinated, with non-dairy milk"
 1102671,VEGAN,N,"Mango, canned"
 1103119,VEGAN,N,"Kale, canned, cooked, no added fat"
-1098354,OMNI,N,"Lamb, roast, cooked, NS as to fat eaten"
+1100495,VEGETARIAN,N,"Vegetarian burger or patty, meatless, no bun"


### PR DESCRIPTION
Fixes #8.

Normally, the presence of tokens that suggest an "omni" food takes precedence over the presence of tokens that suggest veg* foods, so that e.g. "meat and potatoes" is correctly categorized as omni.

This implements another class of tokens that override this behavior for terms that are often used to describe veg* analogues to omni foods (e.g. "vegetarian goulash", "meatless burger patty") and vegan alternatives to vegetarian foods (e.g. "vegan cheese", "plant-based milk").