### PR TITLE
Factor out context manager closing

### DIFF
--- a/fooddata_vegattributes/abstract_indexed_fooddata.py
+++ b/fooddata_vegattributes/abstract_indexed_fooddata.py
@@ -3,19 +3,14 @@ from typing import Iterable, Union
 
 from .fooddata import FoodDataDict
 from .utils.abstract_indexed_json import AbstractIndexedJson
+from .utils.close_on_exit import CloseOnExit
 
 
-class AbstractIndexedFoodDataJson(metaclass=ABCMeta):
+class AbstractIndexedFoodDataJson(CloseOnExit, metaclass=ABCMeta):
   indexed_json: AbstractIndexedJson
 
   @abstractmethod
   def close(self): ...
-
-  def __enter__(self):
-    return self
-
-  def __exit__(self, *args, **kwargs):
-    self.close()
 
   def write_fooddata_dicts(self, ds: Iterable[FoodDataDict]):
     self.indexed_json.write_index_jsonable_tuples(

--- a/fooddata_vegattributes/compressed_indexed_fooddata.py
+++ b/fooddata_vegattributes/compressed_indexed_fooddata.py
@@ -1,13 +1,13 @@
-from contextlib import ExitStack
 from os import PathLike
 from typing import Union
 
 from .abstract_indexed_fooddata import AbstractIndexedFoodDataJson
 from .fooddata import FoodDataDict
 from .utils.compressed_indexed_json import CompressedIndexedJson
+from .utils.close_via_stack import CloseViaStack
 
 
-class CompressedIndexedFoodDataJson(AbstractIndexedFoodDataJson):
+class CompressedIndexedFoodDataJson(CloseViaStack, AbstractIndexedFoodDataJson):
   """
   Compressed, indexed (by FDC ID) FoodData JSON entries stored in a file.
   """
@@ -15,7 +15,6 @@ class CompressedIndexedFoodDataJson(AbstractIndexedFoodDataJson):
     self, compressed_indexed_json: CompressedIndexedJson[FoodDataDict]
   ):
     self.indexed_json = compressed_indexed_json
-    self.close_stack = ExitStack()
 
   @classmethod
   def from_path(
@@ -30,6 +29,3 @@ class CompressedIndexedFoodDataJson(AbstractIndexedFoodDataJson):
     obj = cls(compressed_indexed_json=compressed_indexed_json)
     obj.close_stack.enter_context(compressed_indexed_json)
     return obj
-
-  def close(self):
-    self.close_stack.close()

--- a/fooddata_vegattributes/csv_reference_sample_store.py
+++ b/fooddata_vegattributes/csv_reference_sample_store.py
@@ -7,10 +7,11 @@ from .abstract_reference_sample_store import AbstractReferenceSampleStore
 from .category import Category
 from .reference_sample import ReferenceSample
 from .reference_samples_csv import ReferenceSamplesCsv, ReferenceSampleDict
+from .utils.close_on_exit import CloseOnExit
 
 
 @dataclass
-class CsvReferenceSampleStore(AbstractReferenceSampleStore):
+class CsvReferenceSampleStore(AbstractReferenceSampleStore, CloseOnExit):
   reference_samples_csv: ReferenceSamplesCsv
   food_store: AbstractFoodStore
   close_stack: ExitStack = field(init=False, default_factory=ExitStack)
@@ -30,12 +31,6 @@ class CsvReferenceSampleStore(AbstractReferenceSampleStore):
 
   def close(self):
     self.close_stack.close()
-
-  def __enter__(self):
-    return self
-
-  def __exit__(self, *args, **kwargs):
-    self.close()
 
   def get_all(self) -> List[ReferenceSample]:
     fdc_ids_to_ds = {

--- a/fooddata_vegattributes/indexed_fooddata_food_store.py
+++ b/fooddata_vegattributes/indexed_fooddata_food_store.py
@@ -6,10 +6,11 @@ from typing import Iterable, Mapping, Union
 from .abstract_food_store import AbstractFoodStore
 from .food import Food
 from .compressed_indexed_fooddata import CompressedIndexedFoodDataJson
+from .utils.close_on_exit import CloseOnExit
 
 
 @dataclass
-class IndexedFoodDataFoodStore(AbstractFoodStore):
+class IndexedFoodDataFoodStore(AbstractFoodStore, CloseOnExit):
   indexed_fooddata_json: CompressedIndexedFoodDataJson
   close_stack: ExitStack = field(init=False, default_factory=ExitStack)
 
@@ -24,12 +25,6 @@ class IndexedFoodDataFoodStore(AbstractFoodStore):
 
   def close(self):
     self.close_stack.close()
-
-  def __enter__(self):
-    return self
-
-  def __exit__(self, *args, **kwargs):
-    self.close()
 
   def get_mapped_by_fdc_ids(
     self, fdc_ids: Iterable[int]

--- a/fooddata_vegattributes/indexed_fooddata_food_store.py
+++ b/fooddata_vegattributes/indexed_fooddata_food_store.py
@@ -1,5 +1,4 @@
-from contextlib import ExitStack
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from os import PathLike
 from typing import Iterable, Mapping, Union
 
@@ -7,12 +6,12 @@ from .abstract_food_store import AbstractFoodStore
 from .food import Food
 from .compressed_indexed_fooddata import CompressedIndexedFoodDataJson
 from .utils.close_on_exit import CloseOnExit
+from .utils.close_via_stack import CloseViaStack
 
 
 @dataclass
-class IndexedFoodDataFoodStore(AbstractFoodStore, CloseOnExit):
+class IndexedFoodDataFoodStore(CloseViaStack, AbstractFoodStore, CloseOnExit):
   indexed_fooddata_json: CompressedIndexedFoodDataJson
-  close_stack: ExitStack = field(init=False, default_factory=ExitStack)
 
   @classmethod
   def from_path(
@@ -22,9 +21,6 @@ class IndexedFoodDataFoodStore(AbstractFoodStore, CloseOnExit):
     obj = cls(indexed_fooddata_json=indexed_fooddata_json)
     obj.close_stack.enter_context(indexed_fooddata_json)
     return obj
-
-  def close(self):
-    self.close_stack.close()
 
   def get_mapped_by_fdc_ids(
     self, fdc_ids: Iterable[int]

--- a/fooddata_vegattributes/reference_samples_csv.py
+++ b/fooddata_vegattributes/reference_samples_csv.py
@@ -1,9 +1,9 @@
-from contextlib import ExitStack
 import csv
 from os import PathLike
 from typing import Generator, Iterable, Optional, TypedDict, Union
 
 from .utils.close_on_exit import CloseOnExit
+from .utils.close_via_stack import CloseViaStack
 
 
 class ReferenceSampleDict(TypedDict):
@@ -12,7 +12,7 @@ class ReferenceSampleDict(TypedDict):
   known_failure: bool
   description: Optional[str]
 
-class ReferenceSamplesCsv(CloseOnExit):
+class ReferenceSamplesCsv(CloseViaStack, CloseOnExit):
   """
   CSV file containing reference samples.
 
@@ -27,7 +27,6 @@ class ReferenceSamplesCsv(CloseOnExit):
     csv_writer: Optional[csv.DictWriter]=None,
   ):
     self.file = file
-    self.close_stack = ExitStack()
     self.csv_reader = csv_reader
     self.csv_writer = csv_writer
 
@@ -54,9 +53,6 @@ class ReferenceSamplesCsv(CloseOnExit):
     obj = cls(file=file, csv_reader=csv_reader, csv_writer=csv_writer)
     obj.close_stack.enter_context(file)
     return obj
-
-  def close(self):
-    self.close_stack.close()
 
   def reset_and_write_reference_sample_dicts(
     self,

--- a/fooddata_vegattributes/reference_samples_csv.py
+++ b/fooddata_vegattributes/reference_samples_csv.py
@@ -3,6 +3,8 @@ import csv
 from os import PathLike
 from typing import Generator, Iterable, Optional, TypedDict, Union
 
+from .utils.close_on_exit import CloseOnExit
+
 
 class ReferenceSampleDict(TypedDict):
   fdc_id: int
@@ -10,7 +12,7 @@ class ReferenceSampleDict(TypedDict):
   known_failure: bool
   description: Optional[str]
 
-class ReferenceSamplesCsv:
+class ReferenceSamplesCsv(CloseOnExit):
   """
   CSV file containing reference samples.
 
@@ -55,12 +57,6 @@ class ReferenceSamplesCsv:
 
   def close(self):
     self.close_stack.close()
-
-  def __enter__(self):
-    return self
-
-  def __exit__(self, *args, **kwargs):
-    self.close()
 
   def reset_and_write_reference_sample_dicts(
     self,

--- a/fooddata_vegattributes/utils/abstract_indexed_json.py
+++ b/fooddata_vegattributes/utils/abstract_indexed_json.py
@@ -1,18 +1,14 @@
 from abc import ABCMeta, abstractmethod
 from typing import Generic, Iterable, Tuple, TypeVar
 
+from .close_on_exit import CloseOnExit
+
 
 T = TypeVar("T")
 
-class AbstractIndexedJson(Generic[T], metaclass=ABCMeta):
+class AbstractIndexedJson(Generic[T], CloseOnExit, metaclass=ABCMeta):
   @abstractmethod
   def close(self): ...
-
-  def __enter__(self):
-    return self
-
-  def __exit__(self, *args, **kwargs):
-    self.close()
 
   @abstractmethod
   def write_index_jsonable_tuples(

--- a/fooddata_vegattributes/utils/close_on_exit.py
+++ b/fooddata_vegattributes/utils/close_on_exit.py
@@ -1,0 +1,13 @@
+from abc import abstractmethod
+from contextlib import AbstractContextManager
+
+
+class CloseOnExit(AbstractContextManager):
+  """
+  Mixin
+  """
+  @abstractmethod
+  def close(self): ...
+
+  def __exit__(self, *args, **kwargs):
+    self.close()

--- a/fooddata_vegattributes/utils/close_stack_owner.py
+++ b/fooddata_vegattributes/utils/close_stack_owner.py
@@ -1,0 +1,17 @@
+from contextlib import ExitStack
+from typing import Optional
+
+
+class CloseStackOwner:
+  """
+  Mixin
+  """
+  # implemented the way it is to avoid having to do __init__() shennanigans
+  # (cooperative multiple inheritance and all that)
+  _close_stack: Optional[ExitStack] = None
+
+  @property
+  def close_stack(self) -> ExitStack:
+    if self._close_stack is None:
+      self._close_stack = ExitStack()
+    return self._close_stack

--- a/fooddata_vegattributes/utils/close_via_stack.py
+++ b/fooddata_vegattributes/utils/close_via_stack.py
@@ -1,0 +1,9 @@
+from .close_stack_owner import CloseStackOwner
+
+
+class CloseViaStack(CloseStackOwner):
+  """
+  Mixin
+  """
+  def close(self):
+    self.close_stack.close()

--- a/fooddata_vegattributes/utils/compressed_indexed_json.py
+++ b/fooddata_vegattributes/utils/compressed_indexed_json.py
@@ -1,4 +1,3 @@
-from contextlib import ExitStack
 from io import BytesIO
 import json
 from datetime import datetime
@@ -9,15 +8,15 @@ from tarfile import (
 from typing import cast, Generic, Iterable, Tuple, Union
 
 from .abstract_indexed_json import AbstractIndexedJson, T
+from .close_via_stack import CloseViaStack
 
 
-class CompressedIndexedJson(AbstractIndexedJson, Generic[T]):
+class CompressedIndexedJson(CloseViaStack, AbstractIndexedJson, Generic[T]):
   """
   Compressed, indexed JSON objects stored in a file.
   """
   def __init__(self, tarfile: TarFile):
     self.tarfile = tarfile
-    self.close_stack = ExitStack()
 
   @classmethod
   def from_path(
@@ -36,9 +35,6 @@ class CompressedIndexedJson(AbstractIndexedJson, Generic[T]):
     obj = cls(tarfile=tarfile)
     obj.close_stack.enter_context(tarfile)
     return obj
-
-  def close(self):
-    self.close_stack.close()
 
   def write_index_jsonable_tuples(
     self, index_jsonable_tuples: Iterable[Tuple[str, T]]


### PR DESCRIPTION
Factors `__enter__`, `__exit__` and the `close_stack`-based `close` (along with the existence and initialization of the `close_stack` attribute) out into mixins.